### PR TITLE
Fix crash in arm64-v8a devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ local.properties
 # Eclipse project files
 .classpath
 .project
+
+.idea/
+*.iml

--- a/AntiEmulator/AndroidManifest.xml
+++ b/AntiEmulator/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="diff.strazzere.anti">
 
-    <uses-sdk android:minSdkVersion="21"
+    <uses-sdk
         android:targetSdkVersion="23"
         android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />

--- a/AntiEmulator/build.gradle
+++ b/AntiEmulator/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 'android-29'
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '29.0.3'
 
 
     defaultConfig {
@@ -44,13 +44,15 @@ dependencies {
 }
 
 task ndkBuild(type: Exec, description: "Task to run ndk-build") {
-    commandLine 'ndk-build'
+    def ndkDir = android.ndkDirectory.getAbsolutePath()
+    commandLine ndkDir + "/ndk-build"
 }
 
 tasks.withType(JavaCompile) { compileTask -> compileTask.dependsOn ndkBuild }
 
 task cleanNative(type: Exec, description: "Task to run ndk-build clean") {
-    commandLine 'ndk-build', 'clean'
+    def ndkDir = android.ndkDirectory.getAbsolutePath()
+    commandLine ndkDir + '/ndk-build', 'clean'
 }
 
 clean.dependsOn 'cleanNative'

--- a/AntiEmulator/jni/Application.mk
+++ b/AntiEmulator/jni/Application.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a
 
 APP_PLATFORM := android-21
 

--- a/AntiEmulator/jni/anti.c
+++ b/AntiEmulator/jni/anti.c
@@ -26,8 +26,10 @@ void setupSigTrap() {
 }
 
 // This will cause a SIGSEGV on some QEMU or be properly respected
-void tryBKPT() {
-  __asm__ __volatile__ ("bkpt 255");
+void tryBKPT() {  
+  #if defined(__arm__)
+    __asm__ __volatile__ ("bkpt 255");
+  #endif
 }
 
 jint Java_diff_strazzere_anti_emulator_FindEmulator_qemuBkpt(JNIEnv* env, jobject jObject) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
This PR addresses #14: I added the new architecture and excluded the arm call, as suggested :). I also updated a few other stuff to able to run the app (ndk path, gradle) - I hope that's acceptable.

Thanks a lot for your comment on the issue, and I look forward to your feedback.